### PR TITLE
feat(api): serve QDL board metadata and proxy-cache firehose assets

### DIFF
--- a/apps/api/data/enrichments.json
+++ b/apps/api/data/enrichments.json
@@ -1,1 +1,38 @@
-[]
+[
+  {
+    "slug": "radxa-dragon-q6a",
+    "soc": "QCS6490",
+    "qdl": {
+      "family": "Kodiak",
+      "storage": "ufs",
+      "loader_rel": null,
+      "provision_rel": "radxa-dragon-q6a/provision_ufs31_lun0_only.xml",
+      "edl_entry": "button",
+      "min_imager_version": "2.0.3"
+    }
+  },
+  {
+    "slug": "arduino-uno-q",
+    "soc": "QRB2210",
+    "qdl": {
+      "family": "Agatti",
+      "storage": "emmc",
+      "loader_rel": null,
+      "provision_rel": null,
+      "edl_entry": "jumper",
+      "min_imager_version": "2.0.3"
+    }
+  },
+  {
+    "slug": "radxa-dragon-q8b",
+    "soc": "SC8280XP",
+    "qdl": {
+      "family": "Makena",
+      "storage": "ufs",
+      "loader_rel": null,
+      "provision_rel": "radxa-dragon-q8b/provision_ufs31_lun0_only.xml",
+      "edl_entry": "button",
+      "min_imager_version": "2.0.3"
+    }
+  }
+]

--- a/apps/api/src/routes/qdl.ts
+++ b/apps/api/src/routes/qdl.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from 'fastify';
+import '../types.js';
+
+export function registerQdlRoutes(server: FastifyInstance): void {
+  /**
+   * GET /api/v1/qdl/blob/{family}/{path...}
+   * Serve a cached qcombin firehose loader or UFS provisioning descriptor,
+   * proxying from upstream on first request. The imager verifies the payload
+   * against the SHA-256 digest carried in the board's `qdl` block.
+   */
+  server.get<{ Params: { '*': string } }>('/api/v1/qdl/blob/*', async (request, reply) => {
+    const blob = await server.qdlCache.getBlob(request.params['*']);
+
+    if (!blob) {
+      void reply.status(404);
+      return { error: 'Not Found', statusCode: 404 };
+    }
+
+    void reply.header('Cache-Control', 'public, max-age=86400, immutable');
+    void reply.type(blob.contentType);
+    return reply.send(blob.data);
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -22,7 +22,9 @@ import { registerPageRoutes } from './routes/pages.js';
 import { registerImageRoutes } from './routes/images.js';
 import { registerContactRoutes } from './routes/contact.js';
 import { registerImagerRoutes } from './routes/imager.js';
+import { registerQdlRoutes } from './routes/qdl.js';
 import { ImageCache } from './services/image-cache.js';
+import { QdlAssetCache } from './services/qdl-cache.js';
 
 const PORT = parseInt(process.env['API_PORT'] ?? process.env['PORT'] ?? '3001', 10);
 const HOST = process.env['HOST'] ?? '0.0.0.0';
@@ -79,6 +81,9 @@ async function main(): Promise<void> {
   server.addHook('preHandler', async (request, reply) => {
     if (request.url === '/api/v1/health') return;
     if (request.url.startsWith('/api/v1/images/')) return;
+    // QDL blobs are public firehose assets fetched by the imager's plain download
+    // client (no custom headers), same rationale as images.
+    if (request.url.startsWith('/api/v1/qdl/')) return;
     const client = request.headers['x-armbian-client'];
     if (typeof client !== 'string' || client.length === 0) {
       void reply.status(403).send({ error: 'Client identification required', statusCode: 403 });
@@ -161,7 +166,8 @@ async function main(): Promise<void> {
 
   const store = new DataStore();
   const imageCache = new ImageCache(CACHE_DIR, server.log);
-  const sync = new SyncService(store, server.log, imageCache);
+  const qdlCache = new QdlAssetCache(CACHE_DIR, server.log);
+  const sync = new SyncService(store, server.log, imageCache, qdlCache);
 
   // Initial data load — try disk cache first for fast startup, then sync from network
   const cached = await sync.loadFromCache();
@@ -186,6 +192,7 @@ async function main(): Promise<void> {
   // Decorate Fastify with store and image cache
   server.decorate('store', store);
   server.decorate('imageCache', imageCache);
+  server.decorate('qdlCache', qdlCache);
 
   // --- Routes ---
 
@@ -201,6 +208,7 @@ async function main(): Promise<void> {
   registerImageRoutes(server);
   registerContactRoutes(server);
   registerImagerRoutes(server);
+  registerQdlRoutes(server);
 
   // --- Start ---
 

--- a/apps/api/src/services/datastore.ts
+++ b/apps/api/src/services/datastore.ts
@@ -353,6 +353,7 @@ function toBoardSummary(board: BoardDetail): BoardSummary {
     soc: board.soc,
     architecture: board.architecture,
     summary: board.summary,
+    qdl: board.qdl,
   };
 }
 

--- a/apps/api/src/services/normalizer.ts
+++ b/apps/api/src/services/normalizer.ts
@@ -19,7 +19,10 @@ import type {
   SupportTier,
   KernelBranchInfo,
   BoardMaintainer,
+  QdlMeta,
+  BoardQdl,
 } from '@armbian/schemas';
+import { qdlLoaderRelPath, qdlProvisionRelPath } from '@armbian/schemas';
 import {
   computeSupportTier,
   boardGithubUrl,
@@ -44,6 +47,20 @@ interface EnrichmentData {
   redirects: LegacyRedirectEntry[];
   enrichments: BoardEnrichment[];
   boardConfigSlugs?: Set<string>;
+  /** relPath → SHA-256 of the cached QDL asset, computed by QdlAssetCache during sync. */
+  qdlDigests?: Map<string, string>;
+}
+
+/** Merge a board's QDL enrichment with the digests the API computed for its assets. */
+function buildBoardQdl(qdl: QdlMeta | undefined, digests?: Map<string, string>): BoardQdl | null {
+  if (!qdl) return null;
+  const loaderRel = qdlLoaderRelPath(qdl);
+  const provisionRel = qdlProvisionRelPath(qdl);
+  return {
+    ...qdl,
+    loader_sha256: loaderRel ? (digests?.get(loaderRel) ?? null) : null,
+    provision_sha256: provisionRel ? (digests?.get(provisionRel) ?? null) : null,
+  };
 }
 
 /**
@@ -69,14 +86,6 @@ const VALID_IMAGE_EXTENSIONS: Record<string, ImageFormat> = {
   'hyperv.zip': 'hyperv',
   'hyperv.zip.xz': 'hyperv',
 };
-
-/**
- * Board slugs whose `.tar.xz` archives are Qualcomm Deep Download (QDL)
- * payloads rather than conventional rootfs tarballs. This is a temporary
- * override until upstream starts emitting a dedicated format marker for
- * them; remove entries here once the JSON exposes the distinction natively.
- */
-const QDL_BOARD_SLUGS = new Set<string>(['arduino-uno-q']);
 
 /**
  * Companion file patterns. Each entry knows how to detect a companion file
@@ -161,7 +170,7 @@ function extractPrimaryBaseName(filename: string): string {
   return filename;
 }
 
-function classifyAsset(asset: RawImageAsset): AssetClassification {
+function classifyAsset(asset: RawImageAsset, qdlSlugs: Set<string>): AssetClassification {
   const filename = (asset.file_url.split('/').pop() ?? '').toLowerCase();
 
   // Companion files are matched first because their suffix is more specific
@@ -192,10 +201,11 @@ function classifyAsset(asset: RawImageAsset): AssetClassification {
   let format = VALID_IMAGE_EXTENSIONS[asset.file_extension];
   if (!format) return { kind: 'unknown' };
 
-  // QDL override: a handful of Qualcomm-based boards ship `.tar.xz` archives
-  // that are really QDL payloads, not rootfs tarballs. Upgrade the format so
-  // the UI can label them correctly.
-  if (format === 'rootfs' && QDL_BOARD_SLUGS.has(asset.board_slug)) {
+  // Qualcomm QDL boards ship `.tar.xz` archives that are firehose payloads,
+  // not rootfs tarballs. Upgrade the format for boards carrying a `qdl`
+  // enrichment block; the `rootfs` guard leaves raw UFS `.img.xz` images
+  // (q6a/q8b) untouched — those route via storage, not format.
+  if (format === 'rootfs' && qdlSlugs.has(asset.board_slug)) {
     format = 'qdl';
   }
 
@@ -214,6 +224,7 @@ export class Normalizer {
 
   normalize(raw: RawSyncData, enrichment: EnrichmentData): NormalizedData {
     const enrichmentMap = new Map(enrichment.enrichments.map((e) => [e.slug, e]));
+    const qdlSlugs = new Set(enrichment.enrichments.filter((e) => e.qdl).map((e) => e.slug));
     const maintainerMap = this.buildMaintainerBoardMap(raw.maintainers);
     const partnerMap = this.buildPartnerMap(raw.partners);
 
@@ -227,7 +238,7 @@ export class Normalizer {
     type ClassifiedAsset = { asset: RawImageAsset; classification: AssetClassification };
     const classified: ClassifiedAsset[] = [];
     for (const asset of raw.images) {
-      const classification = classifyAsset(asset);
+      const classification = classifyAsset(asset, qdlSlugs);
       if (classification.kind === 'unknown') {
         unknownExtensions.add(asset.file_extension);
         continue;
@@ -294,6 +305,7 @@ export class Normalizer {
         soc: enrich?.soc ?? null,
         architecture: enrich?.architecture ?? this.detectArchitecture(slug, boardImages) ?? null,
         summary: enrich?.summary ?? null,
+        qdl: buildBoardQdl(enrich?.qdl, enrichment.qdlDigests),
         features: enrich?.features ?? [],
         docs_url: boardDocsUrl(slug),
         forum_url: boardForumUrl(slug),

--- a/apps/api/src/services/qdl-cache.ts
+++ b/apps/api/src/services/qdl-cache.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import type { FastifyBaseLogger } from 'fastify';
+
+/**
+ * QDL firehose loaders and UFS provisioning descriptors published by Armbian in
+ * the qcombin repository. The API caches them so the imager fetches from a
+ * single trusted host (integrity-checked via SHA-256) instead of hammering
+ * GitHub raw, which rate-limits anonymous traffic at 60 req/h.
+ */
+const QCOMBIN_BASE = 'https://raw.githubusercontent.com/armbian/qcombin/main/';
+
+// Same family-relative allowlist enforced by QdlMetaSchema: no traversal, no
+// leading slash, no scheme. relPath never leaves this host after validation.
+const SAFE_REL = /^(?!.*\.\.)[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/;
+
+const FETCH_TIMEOUT_MS = 20_000;
+const MAX_BLOB_BYTES = 8 * 1024 * 1024;
+
+export type QdlAssetKind = 'loader' | 'provision';
+
+export interface QdlAssetRef {
+  /** Family-rooted path, e.g. `Kodiak/prog_firehose_ddr.elf`. */
+  relPath: string;
+  kind: QdlAssetKind;
+}
+
+interface BlobMeta {
+  etag: string | null;
+  lastModified: string | null;
+}
+
+export class QdlAssetCache {
+  private cacheDir: string;
+
+  constructor(
+    cacheDir: string,
+    private log: FastifyBaseLogger,
+  ) {
+    this.cacheDir = join(cacheDir, 'qdl');
+  }
+
+  /** Fetch, validate and hash each referenced asset. Returns relPath → SHA-256 hex. */
+  async warm(refs: QdlAssetRef[]): Promise<Map<string, string>> {
+    const digests = new Map<string, string>();
+    await Promise.all(
+      refs.map(async (ref) => {
+        try {
+          const buffer = await this.ensure(ref.relPath, ref.kind, true);
+          digests.set(ref.relPath, sha256(buffer));
+        } catch (err) {
+          this.log.warn(
+            { relPath: ref.relPath, err: (err as Error).message },
+            'QDL asset warm failed — served without digest',
+          );
+        }
+      }),
+    );
+    return digests;
+  }
+
+  /** Serve a cached blob, fetching from qcombin on miss. Null if invalid or unavailable. */
+  async getBlob(relPath: string): Promise<{ data: Buffer; contentType: string } | null> {
+    if (!SAFE_REL.test(relPath)) return null;
+    const kind: QdlAssetKind = relPath.endsWith('.elf') ? 'loader' : 'provision';
+    try {
+      const data = await this.ensure(relPath, kind, false);
+      return {
+        data,
+        contentType: kind === 'loader' ? 'application/octet-stream' : 'application/xml',
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Return the on-disk blob, fetching from upstream when absent. When
+   * `revalidate` is set (sync path), a cached copy is checked against qcombin
+   * with a conditional GET so an updated asset re-downloads and its digest
+   * changes; on 304, upstream error, or network failure the cached copy is
+   * kept. Request-path reads (`revalidate=false`) serve the cached copy
+   * directly and only hit the network on a miss.
+   */
+  private async ensure(relPath: string, kind: QdlAssetKind, revalidate: boolean): Promise<Buffer> {
+    if (!SAFE_REL.test(relPath)) throw new Error('invalid relPath');
+    const filePath = join(this.cacheDir, relPath);
+
+    let cached: Buffer | null = null;
+    try {
+      const buf = await readFile(filePath);
+      validateBlob(buf, kind);
+      cached = buf;
+    } catch {
+      cached = null; // miss or corrupt on-disk copy
+    }
+
+    if (cached && !revalidate) return cached;
+
+    const headers: Record<string, string> = {};
+    if (cached) {
+      const meta = await this.readMeta(filePath);
+      if (meta?.etag) headers['If-None-Match'] = meta.etag;
+      if (meta?.lastModified) headers['If-Modified-Since'] = meta.lastModified;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(QCOMBIN_BASE + relPath, {
+        signal: controller.signal,
+        redirect: 'follow',
+        headers,
+      });
+    } catch (err) {
+      if (cached) return cached; // network failure during revalidation — keep cached
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (res.status === 304 && cached) return cached;
+    if (!res.ok) {
+      if (cached) return cached; // upstream error — keep cached
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const buffer = Buffer.from(await res.arrayBuffer());
+    if (buffer.byteLength > MAX_BLOB_BYTES)
+      throw new Error(`blob too large (${buffer.byteLength}B)`);
+    validateBlob(buffer, kind);
+
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, buffer);
+    await this.writeMeta(filePath, {
+      etag: res.headers.get('etag'),
+      lastModified: res.headers.get('last-modified'),
+    });
+    return buffer;
+  }
+
+  private async readMeta(filePath: string): Promise<BlobMeta | null> {
+    try {
+      return JSON.parse(await readFile(`${filePath}.meta`, 'utf-8')) as BlobMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeMeta(filePath: string, meta: BlobMeta): Promise<void> {
+    await writeFile(`${filePath}.meta`, JSON.stringify(meta));
+  }
+}
+
+function sha256(buf: Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+/** Reject anything that is not a firehose ELF / UFS provisioning XML before caching it. */
+function validateBlob(buf: Buffer, kind: QdlAssetKind): void {
+  if (kind === 'loader') {
+    const isElf =
+      buf.length >= 4 && buf[0] === 0x7f && buf[1] === 0x45 && buf[2] === 0x4c && buf[3] === 0x46;
+    if (!isElf) throw new Error('not an ELF loader');
+  } else if (!buf.includes(Buffer.from('<ufs '))) {
+    throw new Error('not a UFS provisioning XML');
+  }
+}

--- a/apps/api/src/services/sync.service.ts
+++ b/apps/api/src/services/sync.service.ts
@@ -15,6 +15,7 @@ import type {
   LegacyRedirectEntry,
   BoardEnrichment,
 } from '@armbian/schemas';
+import { qdlLoaderRelPath, qdlProvisionRelPath } from '@armbian/schemas';
 import { DATA_SOURCES, ARMBIAN_URLS } from '@armbian/config';
 import { z } from 'zod';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
@@ -23,6 +24,7 @@ import { dirname, join } from 'node:path';
 import { Normalizer } from './normalizer.js';
 import type { DataStore, ZohoFormTokens } from './datastore.js';
 import type { ImageCache } from './image-cache.js';
+import type { QdlAssetCache, QdlAssetRef } from './qdl-cache.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = join(__dirname, '..', '..', 'data');
@@ -58,8 +60,27 @@ export class SyncService {
     private store: DataStore,
     private log: FastifyBaseLogger,
     private imageCache: ImageCache,
+    private qdlCache: QdlAssetCache,
   ) {
     this.normalizer = new Normalizer();
+  }
+
+  /** Deduplicated qcombin asset references (loader + provisioning XML) across all QDL boards. */
+  private qdlAssetRefs(enrichments: BoardEnrichment[]): QdlAssetRef[] {
+    const refs: QdlAssetRef[] = [];
+    const seen = new Set<string>();
+    const add = (relPath: string | null, kind: QdlAssetRef['kind']) => {
+      if (relPath && !seen.has(relPath)) {
+        seen.add(relPath);
+        refs.push({ relPath, kind });
+      }
+    };
+    for (const e of enrichments) {
+      if (!e.qdl) continue;
+      add(qdlLoaderRelPath(e.qdl), 'loader');
+      add(qdlProvisionRelPath(e.qdl), 'provision');
+    }
+    return refs;
   }
 
   /** Try to load from local disk cache — fast startup without network */
@@ -210,6 +231,10 @@ export class SyncService {
       z.array(BoardEnrichmentSchema),
     );
 
+    // Cache the qcombin firehose loaders / provisioning XML referenced by QDL
+    // boards and hash them, so the served qdl block carries a verifiable digest.
+    const qdlDigests = await this.qdlCache.warm(this.qdlAssetRefs(enrichments ?? []));
+
     // Normalize and load into store
     const normalized = this.normalizer.normalize(
       {
@@ -222,6 +247,7 @@ export class SyncService {
         redirects: redirects ?? [],
         enrichments: enrichments ?? [],
         boardConfigSlugs,
+        qdlDigests,
       },
     );
 

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,13 +1,19 @@
 import type { FastifyInstance } from 'fastify';
 import type { DataStore } from './services/datastore.js';
 import type { ImageCache } from './services/image-cache.js';
+import type { QdlAssetCache } from './services/qdl-cache.js';
 
 /** Extend Fastify instance with our services */
 declare module 'fastify' {
   interface FastifyInstance {
     store: DataStore;
     imageCache: ImageCache;
+    qdlCache: QdlAssetCache;
   }
 }
 
-export type AppInstance = FastifyInstance & { store: DataStore; imageCache: ImageCache };
+export type AppInstance = FastifyInstance & {
+  store: DataStore;
+  imageCache: ImageCache;
+  qdlCache: QdlAssetCache;
+};

--- a/packages/schemas/src/board.ts
+++ b/packages/schemas/src/board.ts
@@ -20,6 +20,73 @@ export const KernelBranchInfoSchema = z.object({
 });
 export type KernelBranchInfo = z.infer<typeof KernelBranchInfoSchema>;
 
+/**
+ * Family-relative path allowlist for QDL asset references. These values are
+ * concatenated into a qcombin fetch URL and a local cache path, so the
+ * lookahead rejects any `..` traversal and the class forbids leading slashes,
+ * `//`, and scheme separators.
+ */
+const QDL_REL_PATH = /^(?!.*\.\.)[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/;
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+/** Default firehose loader filename inside a qcombin family directory. */
+export const QDL_DEFAULT_LOADER = 'prog_firehose_ddr.elf';
+
+const QdlMetaBase = z.object({
+  family: z.string().regex(QDL_REL_PATH),
+  storage: z.enum(['ufs', 'emmc']),
+  loader_rel: z.string().regex(QDL_REL_PATH).nullable(),
+  provision_rel: z.string().regex(QDL_REL_PATH).nullable(),
+  edl_entry: z.enum(['button', 'jumper']),
+  min_imager_version: z.string().regex(/^\d+\.\d+\.\d+$/),
+});
+
+// Paths are stored family-relative; the API prepends `{family}/`, so a leading
+// family segment would double it (e.g. `Makena/Makena/...`).
+const rejectFamilyPrefix = (qdl: z.infer<typeof QdlMetaBase>, ctx: z.RefinementCtx): void => {
+  for (const field of ['loader_rel', 'provision_rel'] as const) {
+    const value = qdl[field];
+    if (value && value.split('/')[0]!.toLowerCase() === qdl.family.toLowerCase()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [field],
+        message: 'must be family-relative, not prefixed with the family directory',
+      });
+    }
+  }
+};
+
+/**
+ * QDL enrichment input, edited by hand in enrichments.json. Lets the imager
+ * resolve the firehose loader family, UFS provisioning descriptor, and
+ * EDL-entry hint without a hardcoded registry.
+ */
+export const QdlMetaSchema = QdlMetaBase.superRefine(rejectFamilyPrefix);
+export type QdlMeta = z.infer<typeof QdlMetaSchema>;
+
+/**
+ * QDL metadata as served on a board: the enrichment fields plus the SHA-256
+ * digests the API computes over the cached loader and provisioning XML, so the
+ * imager can verify integrity after downloading them from the API.
+ */
+export const BoardQdlSchema = QdlMetaBase.extend({
+  loader_sha256: z.string().regex(SHA256_HEX).nullable(),
+  provision_sha256: z.string().regex(SHA256_HEX).nullable(),
+});
+export type BoardQdl = z.infer<typeof BoardQdlSchema>;
+
+/** Family-relative qcombin path of the firehose loader, or null for non-UFS boards. */
+export function qdlLoaderRelPath(
+  qdl: Pick<QdlMeta, 'family' | 'loader_rel' | 'storage'>,
+): string | null {
+  return qdl.storage === 'ufs' ? `${qdl.family}/${qdl.loader_rel ?? QDL_DEFAULT_LOADER}` : null;
+}
+
+/** Family-relative qcombin path of the UFS provisioning XML, or null when absent. */
+export function qdlProvisionRelPath(qdl: Pick<QdlMeta, 'family' | 'provision_rel'>): string | null {
+  return qdl.provision_rel ? `${qdl.family}/${qdl.provision_rel}` : null;
+}
+
 /** Board summary — used in list/catalog endpoints */
 export const BoardSummarySchema = z.object({
   slug: z.string(),
@@ -34,6 +101,7 @@ export const BoardSummarySchema = z.object({
   soc: z.string().nullable(),
   architecture: z.string().nullable(),
   summary: z.string().nullable(),
+  qdl: BoardQdlSchema.nullable(),
 });
 export type BoardSummary = z.infer<typeof BoardSummarySchema>;
 

--- a/packages/schemas/src/raw.ts
+++ b/packages/schemas/src/raw.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { QdlMetaSchema } from './board.js';
 
 /**
  * Raw source schemas — validate upstream JSON from github.armbian.com
@@ -96,5 +97,6 @@ export const BoardEnrichmentSchema = z.object({
   architecture: z.string().optional(),
   features: z.array(z.string()).optional(),
   summary: z.string().optional(),
+  qdl: QdlMetaSchema.optional(),
 });
 export type BoardEnrichment = z.infer<typeof BoardEnrichmentSchema>;


### PR DESCRIPTION
Adds an optional `qdl` block to the board model so the imager can flash Qualcomm EDL boards without a hardcoded registry. The block carries the loader family, UFS provisioning path, EDL-entry hint and a minimum imager version, and it's edited by hand in `enrichments.json`. Adding a board is one JSON entry.

The API also caches the qcombin firehose loader and provisioning descriptors and serves them under `/api/v1/qdl/blob`, computing a SHA-256 for each so the imager fetches from a single host and can verify integrity. Cached blobs revalidate on every sync with a conditional GET, so when an asset changes in qcombin it re-downloads and its digest changes on its own.

First boards registered: Radxa Dragon Q6A and Arduino UNO Q. Radxa Dragon Q8B is in ahead of its upstream images and Makena loader, so it stays inert until both land.
