### PR TITLE
refactor(api): drop min_imager_version from QDL enrichment

### DIFF
--- a/apps/api/data/enrichments.json
+++ b/apps/api/data/enrichments.json
@@ -7,8 +7,7 @@
       "storage": "ufs",
       "loader_rel": null,
       "provision_rel": "radxa-dragon-q6a/provision_ufs31_lun0_only.xml",
-      "edl_entry": "button",
-      "min_imager_version": "2.0.3"
+      "edl_entry": "button"
     }
   },
   {
@@ -19,8 +18,7 @@
       "storage": "emmc",
       "loader_rel": null,
       "provision_rel": null,
-      "edl_entry": "jumper",
-      "min_imager_version": "2.0.3"
+      "edl_entry": "jumper"
     }
   },
   {
@@ -31,8 +29,7 @@
       "storage": "ufs",
       "loader_rel": null,
       "provision_rel": "radxa-dragon-q8b/provision_ufs31_lun0_only.xml",
-      "edl_entry": "button",
-      "min_imager_version": "2.0.3"
+      "edl_entry": "button"
     }
   }
 ]

--- a/packages/schemas/src/board.ts
+++ b/packages/schemas/src/board.ts
@@ -38,7 +38,6 @@ const QdlMetaBase = z.object({
   loader_rel: z.string().regex(QDL_REL_PATH).nullable(),
   provision_rel: z.string().regex(QDL_REL_PATH).nullable(),
   edl_entry: z.enum(['button', 'jumper']),
-  min_imager_version: z.string().regex(/^\d+\.\d+\.\d+$/),
 });
 
 // Paths are stored family-relative; the API prepends `{family}/`, so a leading


### PR DESCRIPTION
The imager now decides whether it can flash a QDL board from a storage-capability check rather than a version floor, so the served `qdl` block no longer needs `min_imager_version`. This removes the field from the `QdlMeta` schema and from every enrichment entry. Older imager builds already ignore unknown fields, so serving the slimmer block stays backward-compatible.